### PR TITLE
Updates styles on notifications

### DIFF
--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -64,14 +64,16 @@ export default function Notification(props: Props) {
         >
             <NotificationWrapper role={role}>
                 <div>
-                    <div style={{ color: colors[icon] }}>
-                        <FontAwesomeIcon icon={icons[icon]} />
+                    <div>
+                        <span style={{ color: colors[icon] }}>
+                            <FontAwesomeIcon icon={icons[icon]} />
+                        </span>
+                        <span>{text}</span>
+                        {subText && <p>{subText}</p>}
                     </div>
-                    <span>{text}</span>
                     {button}
                     {dismiss}
                 </div>
-                {subText && <p>{subText}</p>}
             </NotificationWrapper>
         </CSSTransition>
     );
@@ -80,7 +82,7 @@ export default function Notification(props: Props) {
 const slideIn = keyframes`
     from {
         opacity: 0.15;
-        transform: translateY(-100px);
+        transform: translateY(100%);
     }
 
     to {
@@ -91,16 +93,10 @@ const slideIn = keyframes`
 
 const NotificationWrapper = styled.div`
     background-color: white;
-    padding: ${theme.spacing.medium};
-    font-size: ${theme.fontSizes.plus4};
-
-    &:not(:first-of-type) {
-        border-top: ${theme.borders.default};
-    }
-
-    &:last-of-type {
-        box-shadow: ${theme.shadows.down};
-    }
+    padding: ${theme.spacing.small};
+    font-size: ${theme.fontSizes.small};
+    margin-top: ${theme.spacing.small};
+    box-shadow: ${theme.shadows.shallow};
 
     > div {
         align-items: center;
@@ -114,15 +110,20 @@ const NotificationWrapper = styled.div`
 
     p {
         margin: 0;
-        font-size: ${theme.fontSizes.normal};
+        font-size: ${theme.fontSizes.discrete};
         text-align: left;
+        color: ${theme.colors.grey.medium};
     }
 
     span {
         flex-grow: 1;
-        margin-left: ${theme.spacing.medium};
-        font-size: ${theme.fontSizes.plus3};
+        font-size: ${theme.fontSizes.plus1};
         font-weight: 600;
+        margin-left: ${theme.spacing.small};
+
+        &:first-of-type {
+            margin-left: 0;
+        }
     }
 
     button {
@@ -152,11 +153,15 @@ const NotificationWrapper = styled.div`
 `;
 
 const CloseNotification = styled(CloseButton)`
-    border-color: ${theme.colors.grey.light};
-    background-color: white;
+    background: white;
+    border: 1px solid ${theme.colors.grey.light};
+
+    &:hover {
+        background: ${theme.colors.grey.ultraLight};
+    }
 
     &:before,
     &:after {
-        background-color: ${theme.colors.grey.medium};
+        background: ${theme.colors.grey.medium};
     }
 `;

--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -8,6 +8,7 @@ import {
     faTimesCircle,
 } from '@fortawesome/free-solid-svg-icons';
 import { CSSTransition } from 'react-transition-group';
+import classNames from 'classnames';
 
 import { icons as iconNames, NOTIFICATION_TIMEOUT } from '../const';
 
@@ -36,6 +37,8 @@ type Props = NotificationParam & {
     exit?: boolean,
     text: string,
     subText?: string,
+    isBottom?: Boolean,
+    isSmall?: Boolean,
 };
 
 export default function Notification(props: Props) {
@@ -48,12 +51,15 @@ export default function Notification(props: Props) {
         exit,
         text,
         subText,
+        isBottom,
+        isSmall,
     } = props;
     const button = callToAction ? <button onClick={onCallToAction}>{callToAction}</button> : null;
     const dismiss = dismissable ? (
         <CloseNotification aria-label="Dismiss" title="Dismiss" onClick={removeNotification} />
     ) : null;
     const role = dismissable ? 'status' : 'alert';
+    const classnames = classNames({ 'is-small': isSmall }, { 'is-bottom': isBottom });
     return (
         <CSSTransition
             appear={true}
@@ -62,7 +68,7 @@ export default function Notification(props: Props) {
             timeout={NOTIFICATION_TIMEOUT}
             unmountOnExit={true}
         >
-            <NotificationWrapper role={role}>
+            <NotificationWrapper role={role} className={classnames}>
                 <div>
                     <div>
                         <span style={{ color: colors[icon] }}>
@@ -79,7 +85,7 @@ export default function Notification(props: Props) {
     );
 }
 
-const slideIn = keyframes`
+const bottomSlideIn = keyframes`
     from {
         opacity: 0.15;
         transform: translateY(100%);
@@ -91,12 +97,48 @@ const slideIn = keyframes`
     }
 `;
 
+const topSlideIn = keyframes`
+    from {
+        opacity: 0.15;
+        transform: translateY(-100px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+`;
+
 const NotificationWrapper = styled.div`
     background-color: white;
-    padding: ${theme.spacing.small};
-    font-size: ${theme.fontSizes.small};
-    margin-top: ${theme.spacing.small};
-    box-shadow: ${theme.shadows.shallow};
+    padding: ${theme.spacing.medium};
+    font-size: ${theme.fontSizes.plus4};
+
+    &:not(.is-small):not(.is-bottom) {
+        &:not(:first-of-type) {
+            border-top: ${theme.borders.default};
+        }
+        &:last-of-type {
+            box-shadow: ${theme.shadows.down};
+        }
+    }
+
+    &.is-bottom:not(.is-small) {
+        &:not(:last-of-type) {
+            border-bottom: ${theme.borders.default};
+        }
+        &:first-of-type {
+            box-shadow: ${theme.shadows.down};
+            border-top: ${theme.borders.default};
+        }
+    }
+
+    &.is-small {
+        padding: ${theme.spacing.small};
+        font-size: ${theme.fontSizes.small};
+        margin-top: ${theme.spacing.small};
+        box-shadow: ${theme.shadows.shallow};
+    }
 
     > div {
         align-items: center;
@@ -143,12 +185,20 @@ const NotificationWrapper = styled.div`
         }
     }
 
-    &.notification-appear {
-        animation: ${slideIn} ${theme.animationDuration} ease-in forwards;
+    &.notification-appear:not(.is-bottom) {
+        animation: ${topSlideIn} ${theme.animationDuration} ease-in forwards;
     }
 
-    &.notification-exit {
-        animation: ${slideIn} ${theme.animationDuration} ease-in reverse forwards;
+    &.notification-exit:not(.is-bottom) {
+        animation: ${topSlideIn} ${theme.animationDuration} ease-in reverse forwards;
+    }
+
+    &.is-bottom.notification-appear {
+        animation: ${bottomSlideIn} ${theme.animationDuration} ease-in forwards;
+    }
+
+    &.is-bottom.notification-exit {
+        animation: ${bottomSlideIn} ${theme.animationDuration} ease-in reverse forwards;
     }
 `;
 

--- a/src/components/notification.js
+++ b/src/components/notification.js
@@ -74,8 +74,10 @@ export default function Notification(props: Props) {
                         <span style={{ color: colors[icon] }}>
                             <FontAwesomeIcon icon={icons[icon]} />
                         </span>
-                        <span>{text}</span>
-                        {subText && <p>{subText}</p>}
+                        <div>
+                            <span>{text}</span>
+                            {subText && <p>{subText}</p>}
+                        </div>
                     </div>
                     {button}
                     {dismiss}
@@ -128,7 +130,7 @@ const NotificationWrapper = styled.div`
             border-bottom: ${theme.borders.default};
         }
         &:first-of-type {
-            box-shadow: ${theme.shadows.down};
+            box-shadow: ${theme.shadows.up};
             border-top: ${theme.borders.default};
         }
     }
@@ -145,8 +147,19 @@ const NotificationWrapper = styled.div`
         display: flex;
         justify-content: space-between;
 
+        div:nth-child(1) {
+            display: flex;
+            flex: 1;
+        }
+
         > :nth-child(-n + 2) {
             text-align: left;
+        }
+
+        > div > div {
+            display: flex;
+            flex-direction: column;
+            padding-left: ${theme.spacing.small};
         }
     }
 
@@ -158,7 +171,7 @@ const NotificationWrapper = styled.div`
     }
 
     span {
-        flex-grow: 1;
+        flex-grow: 0;
         font-size: ${theme.fontSizes.plus1};
         font-weight: 600;
         margin-left: ${theme.spacing.small};
@@ -177,7 +190,7 @@ const NotificationWrapper = styled.div`
         }
 
         &:first-of-type:not(:last-of-type) {
-            background-color: none;
+            background-color: white;
             border: ${theme.borders.default};
             border-radius: ${theme.borderRadius.small};
             color: ${theme.colors.blue.default};

--- a/src/components/notificationContainer.js
+++ b/src/components/notificationContainer.js
@@ -2,6 +2,7 @@
 import { connect } from 'react-redux';
 import React, { PureComponent, type Node } from 'react';
 import styled from 'styled-components';
+import classNames from 'classnames';
 import { removeNotification, type NotificationParam } from '../actions/notificationActions';
 import Notification from './notification';
 
@@ -11,11 +12,19 @@ type Props = {
         [string]: NotificationParam & { id: number },
     },
     removeNotification: (id: number) => void,
+    isSmall?: Boolean,
+    isBottom?: Boolean,
 };
 
 export class NotificationContainer extends PureComponent<Props> {
     renderNotifications(): Array<Node> {
-        const { notification, removeNotification, maxNotifications } = this.props;
+        const {
+            notification,
+            removeNotification,
+            maxNotifications,
+            isBottom,
+            isSmall,
+        } = this.props;
 
         return Object.keys(notification)
             .slice(0, maxNotifications)
@@ -25,6 +34,8 @@ export class NotificationContainer extends PureComponent<Props> {
                     <Notification
                         key={`ul-notification-${id}`}
                         removeNotification={() => removeNotification(id)}
+                        isBottom={isBottom}
+                        isSmall={isSmall}
                         {...currentNotification}
                     />
                 );
@@ -32,20 +43,32 @@ export class NotificationContainer extends PureComponent<Props> {
     }
 
     render() {
-        return <Notifications>{this.renderNotifications()}</Notifications>;
+        const { isSmall, isBottom } = this.props;
+        const classnames = classNames({ 'is-small': isSmall }, { 'is-bottom': isBottom });
+        return <Notifications className={classnames}>{this.renderNotifications()}</Notifications>;
     }
 }
 
 const Notifications = styled.div`
-    left: 50%;
+    left: 0;
     position: absolute;
-    bottom: 20px;
-    width: auto;
+    top: 0;
+    width: 100%;
     z-index: 1052;
     display: flex;
     flex-direction: column;
-    transform: translateX(-50%);
     display: flex;
+
+    &.is-bottom {
+        top: auto;
+        bottom: 20px;
+    }
+
+    &.is-small {
+        left: 50%;
+        width: auto;
+        transform: translateX(-50%);
+    }
 `;
 // Modals created with react-aria-modal have a z-index of 1050, and unizin-lib modals have a z-index of 1051
 

--- a/src/components/notificationContainer.js
+++ b/src/components/notificationContainer.js
@@ -37,11 +37,15 @@ export class NotificationContainer extends PureComponent<Props> {
 }
 
 const Notifications = styled.div`
-    left: 0;
+    left: 50%;
     position: absolute;
-    top: 0;
-    width: 100%;
+    bottom: 20px;
+    width: auto;
     z-index: 1052;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(-50%);
+    display: flex;
 `;
 // Modals created with react-aria-modal have a z-index of 1050, and unizin-lib modals have a z-index of 1051
 

--- a/src/components/notificationContainer.js
+++ b/src/components/notificationContainer.js
@@ -62,6 +62,10 @@ const Notifications = styled.div`
     &.is-bottom {
         top: auto;
         bottom: 20px;
+
+        &:not(.is-small) {
+            bottom: 0;
+        }
     }
 
     &.is-small {

--- a/stories/notification.stories.js
+++ b/stories/notification.stories.js
@@ -14,6 +14,8 @@ import { showNotification } from '../src/actions/notificationActions';
 type Props = {
     notification: any,
     removeNotification: number => void,
+    isSmall: Boolean,
+    isBottom: Boolean,
 };
 const Notifications = (props: Props) => <NotificationContainer {...props} />;
 
@@ -56,6 +58,46 @@ storiesOf('Notifications', module)
                     '2': checkNotification,
                     '3': exclamationNotification,
                 },
+            }}
+        />
+    ))
+    .add('All three notifications (bottom)', () => (
+        <Notifications
+            {...{
+                ...baseProps,
+                notification: {
+                    '1': cancelNotification,
+                    '2': checkNotification,
+                    '3': exclamationNotification,
+                },
+                isBottom: true,
+            }}
+        />
+    ))
+    .add('All three notifications (small)', () => (
+        <Notifications
+            {...{
+                ...baseProps,
+                notification: {
+                    '1': cancelNotification,
+                    '2': checkNotification,
+                    '3': exclamationNotification,
+                },
+                isSmall: true,
+            }}
+        />
+    ))
+    .add('All three notifications (small, bottom)', () => (
+        <Notifications
+            {...{
+                ...baseProps,
+                notification: {
+                    '1': cancelNotification,
+                    '2': checkNotification,
+                    '3': exclamationNotification,
+                },
+                isSmall: true,
+                isBottom: true,
             }}
         />
     ))
@@ -109,6 +151,52 @@ storiesOf('Notifications', module)
                         onCallToAction: action('poke'),
                     },
                 },
+            }}
+        />
+    ))
+    .add('Small', () => (
+        <Notifications
+            {...{
+                ...baseProps,
+                notification: {
+                    '1': {
+                        ...checkNotification,
+                        dismissable: true,
+                        subText: "I think there's a bear in my house.",
+                    },
+                },
+                isSmall: true,
+            }}
+        />
+    ))
+    .add('Small (bottom)', () => (
+        <Notifications
+            {...{
+                ...baseProps,
+                notification: {
+                    '1': {
+                        ...checkNotification,
+                        dismissable: true,
+                        subText: "I think there's a bear in my house.",
+                    },
+                },
+                isSmall: true,
+                isBottom: true,
+            }}
+        />
+    ))
+    .add('Bottom', () => (
+        <Notifications
+            {...{
+                ...baseProps,
+                notification: {
+                    '1': {
+                        ...checkNotification,
+                        dismissable: true,
+                        subText: "I think there's a bear in my house.",
+                    },
+                },
+                isBottom: true,
             }}
         />
     ))


### PR DESCRIPTION
I wanted to fix the odd styles on the dismiss button for the notifications. While I was poking around, I decided to see what the notifications would look like with a new design approach.

The newer designs for Order Tool have included a notification design pattern that shows a more inline and less obtrusive approach. We've gotten some feedback about how the messaging can be frustrating due to it's scale (full width) and positioning (overlays the entire navbar).

To combat that issues/concerns we've discussed moving the notifications the to the bottom of the viewport and not going the full width of the viewport.

moves notifications to the bottom of the viewport
changes width of notifications to be auto


