### PR TITLE
fixes a11y validation issues with tooltip

### DIFF
--- a/src/components/tooltip.js
+++ b/src/components/tooltip.js
@@ -12,7 +12,7 @@ export default function Tooltip({ message }: { message: string | Element<any> })
     return (
         <ToolTipContainer>
             <RATooltip eventType="hover" message={message} direction="bottom">
-                <FontAwesomeIcon icon={faQuestionCircle} tabIndex={0} />
+                <FontAwesomeIcon icon={faQuestionCircle} tabIndex={0} aria-hidden="false" aria-label="tooltip icon" />
             </RATooltip>
         </ToolTipContainer>
     );

--- a/stories/__tests__/__snapshots__/index.spec.js.snap
+++ b/stories/__tests__/__snapshots__/index.spec.js.snap
@@ -96,7 +96,7 @@ exports[`Storyshots Future Dates < 13 hours 1`] = `
 
 exports[`Storyshots Future Dates < 24 hours 1`] = `
 <span>
-  at 10:43 AM
+  at 8:43 AM
 </span>
 `;
 
@@ -1732,7 +1732,7 @@ exports[`Storyshots Past Dates < 13 hours 1`] = `
 
 exports[`Storyshots Past Dates < 24 hours 1`] = `
 <span>
-  at 10:45 AM
+  at 8:45 AM
 </span>
 `;
 
@@ -1998,7 +1998,8 @@ exports[`Storyshots Tooltip Tooltip with React element child 1`] = `
     </div>
     <svg
       aria-describedby="ra-tooltip-2"
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="tooltip icon"
       className="svg-inline--fa fa-question-circle fa-w-16 "
       data-icon="question-circle"
       data-prefix="fas"
@@ -2045,7 +2046,8 @@ exports[`Storyshots Tooltip Tooltip with UA text 1`] = `
     </div>
     <svg
       aria-describedby="ra-tooltip-1"
-      aria-hidden="true"
+      aria-hidden="false"
+      aria-label="tooltip icon"
       className="svg-inline--fa fa-question-circle fa-w-16 "
       data-icon="question-circle"
       data-prefix="fas"


### PR DESCRIPTION
Adding the `aria-label` and `aria-hidden="false"` allows for the user to get an understanding of the image's purpose and creates a valid and accessible UX. 

Fixes https://gitlab.com/unizin/apps/ordertool/ordertool-frontend/-/issues/96 and https://gitlab.com/unizin/apps/ordertool/ordertool-frontend/-/issues/93